### PR TITLE
Fix detail fetch range handling and add ESLint configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/components/CalendarOverlayApp.tsx
+++ b/components/CalendarOverlayApp.tsx
@@ -577,10 +577,9 @@ export default function CalendarOverlayApp() {
 
   // ---- Details (opt-in) ----
 
-  async function fetchGraphDetails(day: string): Promise<EventItem[]> {
+  async function fetchGraphDetails(startISO: string, endISO: string): Promise<EventItem[]> {
     const token = await getMsToken();
     if (!token) return [];
-    const { startISO, endISO } = dayBoundsISO(day);
     let url =
       "https://graph.microsoft.com/v1.0/me/calendarView" +
       `?startDateTime=${encodeURIComponent(startISO)}` +
@@ -615,10 +614,9 @@ export default function CalendarOverlayApp() {
     return items.filter((x) => x.end > x.start);
   }
 
-  async function fetchGoogleDetails(day: string): Promise<EventItem[]> {
+  async function fetchGoogleDetails(startISO: string, endISO: string): Promise<EventItem[]> {
     if (!googleTokenRef.current) return [];
-    const { startISO, endISO } = dayBoundsISO(day);
-    let url =
+    const baseUrl =
       "https://www.googleapis.com/calendar/v3/calendars/primary/events" +
       `?singleEvents=true&orderBy=startTime` +
       `&timeMin=${encodeURIComponent(startISO)}` +
@@ -627,7 +625,10 @@ export default function CalendarOverlayApp() {
       `&fields=items(start,end,visibility,transparency,location,summary),nextPageToken`;
 
     const items: EventItem[] = [];
+    let pageToken: string | null = null;
     while (true) {
+      const url =
+        baseUrl + (pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : "");
       const resp = await fetch(url, {
         headers: { Authorization: `Bearer ${googleTokenRef.current}` },
       });
@@ -654,8 +655,8 @@ export default function CalendarOverlayApp() {
           isPrivate: isPriv,
         });
       }
-      if (!data.nextPageToken) break;
-      url += `&pageToken=${data.nextPageToken}`;
+      pageToken = data.nextPageToken ?? null;
+      if (!pageToken) break;
     }
     return items.filter((x) => x.end > x.start);
   }
@@ -665,7 +666,7 @@ export default function CalendarOverlayApp() {
     setLoading(true);
     setErr(null);
     try {
-      const { startISO, endISO } = view === 'day' ? dayBoundsISO(date) : weekBoundsISO(date);
+      const { startISO, endISO } = view === "day" ? dayBoundsISO(date) : weekBoundsISO(date);
 
       const tasks: Promise<any>[] = [fetchGraphFreeBusy(startISO, endISO), fetchGoogleFreeBusy(startISO, endISO)];
       const [msBusy, gBusy] = await Promise.all(tasks);
@@ -685,7 +686,7 @@ export default function CalendarOverlayApp() {
       setBusy(busyBlocks);
 
       if (detailsMode) {
-        const detTasks: Promise<any>[] = [fetchGraphDetails(date), fetchGoogleDetails(date)];
+        const detTasks: Promise<any>[] = [fetchGraphDetails(startISO, endISO), fetchGoogleDetails(startISO, endISO)];
         const [msDet, gDet] = await Promise.all(detTasks);
         setEvents([...msDet, ...gDet].sort((a, b) => a.start.getTime() - b.start.getTime()));
       } else {


### PR DESCRIPTION
## Summary
- update the Microsoft and Google detail fetchers to work on ISO ranges so week view loads complete data and Google pagination no longer reuses previous URLs
- add a Next.js ESLint configuration to avoid the interactive lint wizard

## Testing
- npm run lint *(fails: ESLint must be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d6e4adf43c8332adeed4cb51e7025d