### PR TITLE
Fix detail fetch range handling, add ESLint configuration, and type Google event response

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}


### PR DESCRIPTION
## Summary
- update the Microsoft and Google detail fetchers to work on ISO ranges so week view loads complete data and Google pagination no longer reuses previous URLs
- add a Next.js ESLint configuration to avoid the interactive lint wizard
- annotate the Google detail fetcher with explicit response types so TypeScript no longer reports implicit any errors

## Testing
- npm run lint *(fails: ESLint must be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d6e4adf43c8332adeed4cb51e7025d